### PR TITLE
sessionが期限切れにならないように

### DIFF
--- a/model.py
+++ b/model.py
@@ -29,7 +29,7 @@ class OhuroRecords(Base):
         """
         お風呂チャレンジの成功記録を保存する
         """
-        Session = sessionmaker(bind=conn)
+        Session = sessionmaker(bind=conn, expire_on_commit=False)
         session = Session()
         session.add(self)
         session.commit()
@@ -39,7 +39,7 @@ class OhuroRecords(Base):
         """
         お風呂チャレンジのすべての成功記録を取得する
         """
-        Session = sessionmaker(bind=conn)
+        Session = sessionmaker(bind=conn, expire_on_commit=False)
         session = Session()
         records_all = (
             session.query(OhuroRecords).filter(OhuroRecords.user == user_id).all()
@@ -52,7 +52,7 @@ class OhuroRecords(Base):
         """
         1週間のお風呂チャレンジの成功記録を取得する
         """
-        Session = sessionmaker(bind=conn)
+        Session = sessionmaker(bind=conn, expire_on_commit=False)
         session = Session()
         records_weekly = (
             session.query(OhuroRecords)


### PR DESCRIPTION
本番環境でのみ、進捗表示をすると
```
ERROR:slack_bolt.App:Failed to run listener function (error: Instance <OhuroRecords at 0x7f99751aae30> is not bound to a Session
```
のエラーが出た

2回Sessionを作るようにしたのが悪さしたっぽい？
`expire_on_commit = False` を指定したら解決した



- https://docs.sqlalchemy.org/en/20/orm/session_basics.html#committing
- https://qiita.com/t2kojima/items/5c7f9978f98b1a897d73#%E8%BF%BD%E8%A8%98-instance--is-not-bound-to-a-session
